### PR TITLE
Integrate remote Ollama host support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "local-agent (dev)",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11-bookworm",
+  "remoteUser": "vscode",
+  "mounts": [
+    "type=volume,source=local-agent-workroot,target=/workspaces/local-agent-workroot"
+  ],
+  "remoteEnv": {
+    "LOCAL_AGENT_WORKROOT": "/workspaces/local-agent-workroot"
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && pip install -e '.[dev]' && python - <<'PY'\\nfrom pathlib import Path\\nroot = Path('/workspaces/local-agent-workroot')\\nfor path in [root, root/'allowed', root/'allowed/corpus', root/'allowed/scratch', root/'runs']:\\n    path.mkdir(parents=True, exist_ok=True)\\nPY",
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-python.python"],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      }
+    }
+  }
+}

--- a/OPERATOR_QUICKREF.md
+++ b/OPERATOR_QUICKREF.md
@@ -4,7 +4,7 @@ This is the short runbook. For full architecture and policy detail, see `README.
 
 ## 1) Fast start checklist
 
-1. Ollama is up:
+1. Ollama is up (or reachable remotely). Default `http://127.0.0.1:11434`; override with `--ollama-base-url` or env (`LOCAL_AGENT_OLLAMA_BASE_URL` > `OLLAMA_BASE_URL` > config).
 ```bash
 curl http://127.0.0.1:11434/api/tags
 ```
@@ -58,6 +58,7 @@ python -m agent memory list --json
 python -m agent doctor
 python -m agent doctor --no-ollama
 python -m agent doctor --require-phase3 --json
+python -m agent doctor --ollama-base-url http://lan-host:11434
 local-agent chat "ping"
 local-agent ask "Summarize the indexed notes about coherence."
 local-agent embed --json
@@ -217,3 +218,4 @@ python -m agent ask "Read dupe.md and summarize it."
 5. Re-run with `--workroot` (if needed), `--fast`, `--big`, or `--full` as needed.
    For offline preflight, use `python -m agent doctor --no-ollama`.
    Under `phase3.embed.provider: torch`, retrieval smoke still runs with `--no-ollama`.
+   For remote Ollama, pass `--ollama-base-url` or set `LOCAL_AGENT_OLLAMA_BASE_URL=http://<lan-host>:11434`.

--- a/README.md
+++ b/README.md
@@ -478,6 +478,20 @@ Current defaults in this repo are intentionally conservative:
 - roots limited to configured `../local-agent-workroot/allowed/` and `../local-agent-workroot/runs/`
 - absolute/hidden path denial enabled
 
+## Ollama host selection (local vs remote)
+
+- Precedence: `--ollama-base-url` flag > `LOCAL_AGENT_OLLAMA_BASE_URL` env > `OLLAMA_BASE_URL` env > `configs/default.yaml`.
+- Values must include `http://` or `https://` and a host (optionally `:port`); trailing slash is trimmed and invalid values fail fast.
+- Local default: `http://127.0.0.1:11434`.
+- Remote/LAN: set `LOCAL_AGENT_OLLAMA_BASE_URL=http://<lan-host>:11434` (or use `--ollama-base-url`) and the same resolved host is used by doctor, embed, ask/chat, and retrieval smokes.
+- Devcontainer/Codespaces: the container does not run Ollama; point `LOCAL_AGENT_OLLAMA_BASE_URL` at a host you control on the LAN/VPN. Do not expose Ollama to the public internet; keep it firewalled.
+
+## Optional devcontainer / Codespaces
+
+- A minimal `.devcontainer/devcontainer.json` is provided for Python 3.11. It mounts a persistent volume at `/workspaces/local-agent-workroot` and exports `LOCAL_AGENT_WORKROOT` there (workroot stays outside the repo).
+- `postCreateCommand` installs the project in editable mode with dev extras (`pip install -e ".[dev]"`) and creates the expected workroot subdirectories.
+- Codespaces/devcontainer sessions should point at a remote/LAN Ollama host via `LOCAL_AGENT_OLLAMA_BASE_URL` or `--ollama-base-url`; do not assume Ollama is running inside the container.
+
 ## Error codes and troubleshooting
 
 Typed failure format:

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -55,6 +55,11 @@ from agent.phase3 import (
 from agent.protocol import ToolCall, try_parse_tool_call
 from agent.retrieval import RetrievalResult, retrieve
 from agent.tools import TOOLS, ToolError, configure_tool_security, get_read_text_file_policy
+from agent.ollama_config import (
+    OLLAMA_BASE_URL_ENV,
+    OLLAMA_BASE_URL_FALLBACK_ENV,
+    resolve_ollama_base_url,
+)
 
 
 DEFAULT_CONFIG: Dict[str, Any] = {
@@ -712,6 +717,7 @@ def collect_doctor_checks(
         "retrieval_smoke_ran": False,
         "retrieval_smoke_ok": False,
         "retrieval_smoke_reason": "",
+        "ollama_base_url": _string_config_value(cfg.get("ollama_base_url")),
     }
     phase3_cfg = _build_phase3_cfg(cfg)
     embeddings_db_path = resolve_embeddings_db_path(phase3_cfg, security_root)
@@ -1256,6 +1262,7 @@ def run_doctor(
             ],
             "phase3": phase3_summary,
             "resolved_config_path": _path_to_str(resolved_config_path),
+            "ollama_base_url": _string_config_value(cfg.get("ollama_base_url")),
         }
         payload.update(root_log_fields(runtime_roots))
         print_output(json.dumps(payload, ensure_ascii=False))
@@ -3176,6 +3183,15 @@ def main() -> int:
         default=None,
         help=f"Data root for runs/corpus/scratch (or set {WORKROOT_ENV_VAR}).",
     )
+    parser.add_argument(
+        "--ollama-base-url",
+        type=str,
+        default=None,
+        help=(
+            "Override Ollama host (scheme+host[:port]). "
+            f"Precedence: flag > {OLLAMA_BASE_URL_ENV} > {OLLAMA_BASE_URL_FALLBACK_ENV} > config."
+        ),
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_chat = sub.add_parser("chat", help="Send a single prompt.")
@@ -3321,6 +3337,12 @@ def main() -> int:
     try:
         loaded_cfg, loaded_cfg_path = load_config_with_path()
         cfg = deep_merge_config(DEFAULT_CONFIG, loaded_cfg)
+        cfg["ollama_base_url"] = resolve_ollama_base_url(
+            cli_override=getattr(args, "ollama_base_url", None),
+            env=os.environ,
+            config_value=cfg.get("ollama_base_url"),
+            default=DEFAULT_CONFIG.get("ollama_base_url"),
+        )
         roots = resolve_runtime_roots(
             resolved_config_path=loaded_cfg_path,
             cfg=cfg,

--- a/agent/ollama_config.py
+++ b/agent/ollama_config.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from typing import Mapping, Optional
+from urllib.parse import urlparse
+
+OLLAMA_BASE_URL_ENV = "LOCAL_AGENT_OLLAMA_BASE_URL"
+OLLAMA_BASE_URL_FALLBACK_ENV = "OLLAMA_BASE_URL"
+
+
+def _normalize_ollama_base_url(raw: str) -> str:
+    text = str(raw).strip()
+    if not text:
+        raise ValueError("Ollama base URL is empty")
+    parsed = urlparse(text)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Ollama base URL must include http or https scheme")
+    if not parsed.netloc:
+        raise ValueError("Ollama base URL must include host or host:port")
+    return text.rstrip("/")
+
+
+def resolve_ollama_base_url(
+    *,
+    cli_override: Optional[str],
+    env: Optional[Mapping[str, str]],
+    config_value: Optional[str],
+    default: Optional[str] = None,
+) -> str:
+    environment = env or os.environ
+    candidates = [
+        cli_override,
+        environment.get(OLLAMA_BASE_URL_ENV),
+        environment.get(OLLAMA_BASE_URL_FALLBACK_ENV),
+        config_value,
+        default,
+    ]
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        return _normalize_ollama_base_url(candidate)
+
+    raise ValueError(
+        "Ollama base URL not configured. Set --ollama-base-url, "
+        f"{OLLAMA_BASE_URL_ENV}, {OLLAMA_BASE_URL_FALLBACK_ENV}, or configure ollama_base_url."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = ["requests", "PyYAML"]
 
 [project.optional-dependencies]
 torch-embed = ["torch", "transformers", "sentence-transformers"]
+dev = ["pytest>=7"]
 
 [project.scripts]
 local-agent = "agent.__main__:main"

--- a/tests/test_ollama_config.py
+++ b/tests/test_ollama_config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import unittest
+
+from agent.ollama_config import (
+    OLLAMA_BASE_URL_ENV,
+    OLLAMA_BASE_URL_FALLBACK_ENV,
+    resolve_ollama_base_url,
+)
+
+
+class OllamaConfigTests(unittest.TestCase):
+    def test_cli_override_wins_and_normalizes(self) -> None:
+        base_url = resolve_ollama_base_url(
+            cli_override="https://cli.example:11434/",
+            env={OLLAMA_BASE_URL_ENV: "http://env.example:11434"},
+            config_value="http://config.example:11434",
+        )
+        self.assertEqual(base_url, "https://cli.example:11434")
+
+    def test_prefers_local_agent_env_over_generic(self) -> None:
+        base_url = resolve_ollama_base_url(
+            cli_override=None,
+            env={
+                OLLAMA_BASE_URL_ENV: "http://lan-host:11434",
+                OLLAMA_BASE_URL_FALLBACK_ENV: "http://generic:11434",
+            },
+            config_value="http://config.example:11434",
+        )
+        self.assertEqual(base_url, "http://lan-host:11434")
+
+    def test_uses_generic_env_when_primary_missing(self) -> None:
+        base_url = resolve_ollama_base_url(
+            cli_override=None,
+            env={OLLAMA_BASE_URL_FALLBACK_ENV: "http://generic:11434/"},
+            config_value="http://config.example:11434",
+        )
+        self.assertEqual(base_url, "http://generic:11434")
+
+    def test_config_used_when_no_overrides(self) -> None:
+        base_url = resolve_ollama_base_url(
+            cli_override=None,
+            env={},
+            config_value="http://config.example:11434/",
+        )
+        self.assertEqual(base_url, "http://config.example:11434")
+
+    def test_default_used_when_config_missing(self) -> None:
+        base_url = resolve_ollama_base_url(
+            cli_override=None,
+            env={},
+            config_value=None,
+            default="http://default:11434",
+        )
+        self.assertEqual(base_url, "http://default:11434")
+
+    def test_scheme_is_required(self) -> None:
+        with self.assertRaises(ValueError):
+            resolve_ollama_base_url(
+                cli_override="localhost:11434",
+                env={},
+                config_value=None,
+                default=None,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implement support for configuring a remote Ollama host, allowing users to specify the host via command-line arguments or environment variables. This change includes updates to the documentation and introduces a minimal devcontainer configuration for development purposes.